### PR TITLE
ci: use changelog entries for GitHub release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,9 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+      - name: Extract release notes from CHANGELOG.md
+        run: |
+          python3 scripts/extract-changelog-release.py "${GITHUB_REF_NAME#v}" > /tmp/release-notes.md
       - uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe
         with:
-          generate_release_notes: true
+          body_path: /tmp/release-notes.md

--- a/scripts/extract-changelog-release.py
+++ b/scripts/extract-changelog-release.py
@@ -14,6 +14,10 @@ def main() -> int:
 
     version = sys.argv[1].removeprefix("v")
     changelog_path = Path("CHANGELOG.md")
+    if not changelog_path.exists():
+        print(f"changelog not found: {changelog_path}", file=sys.stderr)
+        return 1
+
     content = changelog_path.read_text(encoding="utf-8")
 
     heading_pattern = re.compile(
@@ -27,7 +31,11 @@ def main() -> int:
 
     start = start_match.end()
     next_heading_match = re.search(r"^## \[", content[start:], re.MULTILINE)
-    reference_block_match = re.search(r"^\[[^\]]+\]:\s+", content[start:], re.MULTILINE)
+    reference_block_match = re.search(
+        r"^\[[^\]]+\]:\s+https?://",
+        content[start:],
+        re.MULTILINE,
+    )
 
     end_candidates = [len(content)]
     if next_heading_match:

--- a/scripts/extract-changelog-release.py
+++ b/scripts/extract-changelog-release.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: extract-changelog-release.py <version>", file=sys.stderr)
+        return 1
+
+    version = sys.argv[1].removeprefix("v")
+    changelog_path = Path("CHANGELOG.md")
+    content = changelog_path.read_text(encoding="utf-8")
+
+    heading_pattern = re.compile(
+        rf"^## \[{re.escape(version)}\] - .*?$",
+        re.MULTILINE,
+    )
+    start_match = heading_pattern.search(content)
+    if start_match is None:
+        print(f"version {version} not found in {changelog_path}", file=sys.stderr)
+        return 1
+
+    start = start_match.end()
+    next_heading_match = re.search(r"^## \[", content[start:], re.MULTILINE)
+    reference_block_match = re.search(r"^\[[^\]]+\]:\s+", content[start:], re.MULTILINE)
+
+    end_candidates = [len(content)]
+    if next_heading_match:
+        end_candidates.append(start + next_heading_match.start())
+    if reference_block_match:
+        end_candidates.append(start + reference_block_match.start())
+
+    end = min(end_candidates)
+
+    section = content[start:end].strip()
+    if not section:
+        print(f"version {version} has no changelog body", file=sys.stderr)
+        return 1
+
+    print(section)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- extract the tagged version section from CHANGELOG.md during the release workflow
- use that extracted section as the GitHub Release body instead of GitHub-generated notes
- keep release-note generation aligned with the changelog we maintain in-repo

## Verification
- python3 scripts/extract-changelog-release.py 0.1.0
- python3 scripts/extract-changelog-release.py 0.1.1
- run the helper from a directory without CHANGELOG.md to confirm a clean error

## Why
The current release workflow generates sparse release notes by default. This makes future GitHub Releases reflect the versioned changelog entry directly, which matches how we manually repaired v0.1.0 and v0.1.1.