### PR TITLE
fix(security): update vulnerable Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -1550,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- update `quinn-proto` from 0.11.14 to 0.11.15 to address RUSTSEC-2026-0185
- update `rustls-webpki` from 0.103.10 to 0.103.13 to address RUSTSEC-2026-0098, RUSTSEC-2026-0099, and RUSTSEC-2026-0104
- keep the existing dependency constraints and workflow unchanged

## Verification
- `git diff --check`
- lockfile entries and crates.io checksums verified for both upgrades
- GitHub Actions Security workflow should run Cargo Audit, Cargo Deny, and Cargo Vet on this branch

Resolves the actionable dependency findings from Security run 29670978465.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WeShipWork/codesmith/langfuse-rs/pr/7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788898190&installation_model_id=20011&pr_number=7&repository=WeShipWork%2Flangfuse-rs&return_to=https%3A%2F%2Fgithub.com%2FWeShipWork%2Flangfuse-rs%2Fpull%2F7&signature=66fa37958341f0ae15c6ca9dc78e7c114d8c54befce3611ec696bc67ee6941b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->