### PR TITLE
fix(ci): restrict workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: '0 0 * * 0'  # Weekly on Sunday at midnight UTC
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## Summary
- Add an explicit workflow-level `contents: read` permission to all GitHub Actions workflows.
- Preserve the release job's existing `contents: write` permission required to create GitHub Releases.
- Resolves CodeQL alert #1 and the identical sibling alerts for the other workflow jobs.

## Verification
- Parsed all three workflow files successfully with PyYAML.
- Confirmed the diff contains only the three intended permission blocks.
- Confirmed the release job write override remains present.

## Security impact
This follows the CodeQL recommendation and prevents unrelated `GITHUB_TOKEN` permissions from being granted to workflow jobs by default.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WeShipWork/codesmith/langfuse-rs/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788898193&installation_model_id=20011&pr_number=8&repository=WeShipWork%2Flangfuse-rs&return_to=https%3A%2F%2Fgithub.com%2FWeShipWork%2Flangfuse-rs%2Fpull%2F8&signature=037fc17b9fc952a2e106ce94412895d8143760fbae7d996df9771318a95b0d8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->